### PR TITLE
Updating "request" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "async": "^0.6.2",
-    "request": "~2.34.0"
+    "request": "~2.42.0"
   },
   "optionalDependencies": {
     "tough-cookie": ">=0.12.0",


### PR DESCRIPTION
There was a security update to the **qs** module in **request@2.40.0**, see:
- https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking
- https://nodesecurity.io/advisories/qs_dos_memory_exhaustion
