### PR TITLE
Added logBody option and documented old & new ways of logging the body.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,6 +41,17 @@ module.exports = function(grunt) {
         },
         dest: 'tmp/basic.html'
       },
+      justLog: {
+        options: {
+          url: 'http://www.j-g-w.info',
+          logBody: true
+        }
+      },
+      noSaveOrLog: {
+        options: {
+          url: 'http://www.j-g-w.info'
+        }
+      },
       closure: {
         options: {
           form: {
@@ -105,7 +116,7 @@ module.exports = function(grunt) {
 
     // Unit tests.
     nodeunit: {
-      tests: ['test/*_test.js'],
+      tests: ['test/*_test.js']
     },
 
   });

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ grunt-http uses the [request](https://github.com/mikeal/request) module under th
 - `httpSignature` - Options for the [HTTP Signature Scheme](https://github.com/joyent/node-http-signature/blob/master/http_signing.md) using [Joyent's library](https://github.com/joyent/node-http-signature). The `http-signature` module must be installed and the keyId and key properties must be specified.
 - `localAddress` - Local interface to bind for network connections.
 - `ignoreErrors` - Ignore the status code returned (if any).
+- `logBody` - Outputs the response body in the logs.  This can also be set at runtime by using --logBody=true on the command.
 
 There are a few optional dependencies you'll need to install to get certain functionality from this module.
 

--- a/tasks/http.js
+++ b/tasks/http.js
@@ -14,7 +14,7 @@ var request = require('request'),
 
 module.exports = function (grunt) {
 
-  function responseHandler(dest, ignoreErrors, callback, done) {
+  function responseHandler(dest, ignoreErrors, logBody, callback, done) {
     return function (error, response, body) {
 
       response = response || { statusCode: 0 };
@@ -28,7 +28,7 @@ module.exports = function (grunt) {
       }
 
       grunt.log.ok(response.statusCode);
-      if (grunt.option("logBody")) {
+      if (logBody) {
         grunt.log.writeln(body);
       }
 
@@ -52,9 +52,11 @@ module.exports = function (grunt) {
 
     var options = this.options({
           ignoreErrors: false,
-          sourceField: 'body'
+          sourceField: 'body',
+          logBody: false
         }),
         done = this.async(),
+        logBody = grunt.option("logBody") || options.logBody,
         sourceField = options.sourceField,
         sourcePath = sourceField.split('.'),
         sourceKey = sourcePath.pop(),
@@ -91,7 +93,7 @@ module.exports = function (grunt) {
       if (typeof(options.json) === 'function') {
         options.json = options.json();
       }
-      callback = responseHandler(file.dest, options.ignoreErrors, options.callback, next);
+      callback = responseHandler(file.dest, options.ignoreErrors, logBody, options.callback, next);
       r = request(options, callback);
       if (formCallback) {
         form = r.form();


### PR DESCRIPTION
We're using grunt http to share REST calls between team members, a simplified version of our use-case is that we want a `grunt http:devConfig` which is going to call our config endpoint on dev and show us the JSON.  To display the response body we've ended up writing a very simple callback.

This pull request does 2 things that would help our team:

1. Documents the existing feature `--logBody=true`
We went looking for this feature and didn't know it existed until I looked through the codebase.

2. Allowed an option to set logBody
In our use-case specifying `--logBody=true` manually every time we use `grunt http:devConfig` isn't particularly smooth.  We can now specify that devConfig should always log the response body we can use the simple command to display the output.  (see `grunt http:justLog` for an example)

If you're happy with this feature I'd like to discuss the test approach.  Currently you're generating output files, then the unit tests are just asserting against them - that means that the unit tests can only really test the features which affect the outputted files..  I'd like to add another test file and use something like https://github.com/cjohansen/sinon-nodeunit to mock out the grunt api and (for this particular Pull Request) make sure that grunt.log.writeln was called with body in some circumstances and not others.  I believe that these tests would also lead the way for other tests covering other runtime features & behaviour.

Should I:
 a) Go ahead and test my runtime behaviour, then re-raise the PR (my preference)
 b) Give up, it's not going to get merged anyway (preferably with a reason)
 c) Wait and discuss the options we have for testing this feature and other features like it
 ... or something else :)