### PR TITLE
Upgrade version of `request` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "async": "^1.5.0",
-    "request": "~2.67.0"
+    "request": "^2.83.0"
   },
   "optionalDependencies": {
     "tough-cookie": ">=0.12.0",


### PR DESCRIPTION
Fixes NSP report issues by upgrading `request` and its dependencies to newer version.

https://nodesecurity.io/advisories/130
https://nodesecurity.io/advisories/309
https://nodesecurity.io/advisories/525